### PR TITLE
feat: list コマンドのフィルタを Backlog API と全網羅にする (#18)

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1306,7 +1306,115 @@ paths:
             type: array
             items:
               type: integer
+        - name: issueTypeId[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: categoryId[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: versionId[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: milestoneId[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
         - name: statusId[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: priorityId[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: assigneeId[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: createdUserId[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: resolutionId[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: parentChild
+          in: query
+          schema:
+            type: integer
+        - name: attachment
+          in: query
+          schema:
+            type: boolean
+        - name: sharedFile
+          in: query
+          schema:
+            type: boolean
+        - name: keyword
+          in: query
+          schema:
+            type: string
+        - name: createdSince
+          in: query
+          schema:
+            type: string
+        - name: createdUntil
+          in: query
+          schema:
+            type: string
+        - name: updatedSince
+          in: query
+          schema:
+            type: string
+        - name: updatedUntil
+          in: query
+          schema:
+            type: string
+        - name: startDateSince
+          in: query
+          schema:
+            type: string
+        - name: startDateUntil
+          in: query
+          schema:
+            type: string
+        - name: dueDateSince
+          in: query
+          schema:
+            type: string
+        - name: dueDateUntil
+          in: query
+          schema:
+            type: string
+        - name: id[]
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+        - name: parentIssueId[]
           in: query
           schema:
             type: array

--- a/packages/backlog/internal/api/issue.go
+++ b/packages/backlog/internal/api/issue.go
@@ -196,7 +196,54 @@ func (c *Client) GetIssuesCount(ctx context.Context, opts *IssueListOptions) (in
 	params := backlog.GetIssuesCountParams{}
 	if opts != nil {
 		params.ProjectId = opts.ProjectIDs
+		params.IssueTypeId = opts.IssueTypeIDs
+		params.CategoryId = opts.CategoryIDs
+		params.VersionId = opts.VersionIDs
+		params.MilestoneId = opts.MilestoneIDs
 		params.StatusId = opts.StatusIDs
+		params.PriorityId = opts.PriorityIDs
+		params.AssigneeId = opts.AssigneeIDs
+		params.CreatedUserId = opts.CreatedUserIDs
+		params.ResolutionId = opts.ResolutionIDs
+		params.ID = opts.IDs
+		params.ParentIssueId = opts.ParentIssueIDs
+
+		if opts.ParentChild > 0 {
+			params.ParentChild = backlog.NewOptInt(opts.ParentChild)
+		}
+		if opts.Attachment != nil {
+			params.Attachment = backlog.NewOptBool(*opts.Attachment)
+		}
+		if opts.SharedFile != nil {
+			params.SharedFile = backlog.NewOptBool(*opts.SharedFile)
+		}
+		if opts.Keyword != "" {
+			params.Keyword = backlog.NewOptString(opts.Keyword)
+		}
+		if opts.CreatedSince != "" {
+			params.CreatedSince = backlog.NewOptString(opts.CreatedSince)
+		}
+		if opts.CreatedUntil != "" {
+			params.CreatedUntil = backlog.NewOptString(opts.CreatedUntil)
+		}
+		if opts.UpdatedSince != "" {
+			params.UpdatedSince = backlog.NewOptString(opts.UpdatedSince)
+		}
+		if opts.UpdatedUntil != "" {
+			params.UpdatedUntil = backlog.NewOptString(opts.UpdatedUntil)
+		}
+		if opts.StartDateSince != "" {
+			params.StartDateSince = backlog.NewOptString(opts.StartDateSince)
+		}
+		if opts.StartDateUntil != "" {
+			params.StartDateUntil = backlog.NewOptString(opts.StartDateUntil)
+		}
+		if opts.DueDateSince != "" {
+			params.DueDateSince = backlog.NewOptString(opts.DueDateSince)
+		}
+		if opts.DueDateUntil != "" {
+			params.DueDateUntil = backlog.NewOptString(opts.DueDateUntil)
+		}
 	}
 
 	res, err := c.backlogClient.GetIssuesCount(ctx, params)

--- a/packages/backlog/internal/api/notification.go
+++ b/packages/backlog/internal/api/notification.go
@@ -7,12 +7,6 @@ import (
 	"strconv"
 )
 
-// NotificationReason は通知理由
-type NotificationReason struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
-}
-
 // NotificationIssue は通知に関連する課題
 type NotificationIssue struct {
 	ID       int    `json:"id"`
@@ -36,7 +30,7 @@ type NotificationPR struct {
 type UserNotification struct {
 	ID                  int                  `json:"id"`
 	AlreadyRead         bool                 `json:"alreadyRead"`
-	Reason              NotificationReason   `json:"reason"`
+	Reason              int                  `json:"reason"`
 	ResourceAlreadyRead bool                 `json:"resourceAlreadyRead"`
 	Project             Project              `json:"project"`
 	Issue               *NotificationIssue   `json:"issue"`
@@ -49,11 +43,11 @@ type UserNotification struct {
 
 // NotificationListOptions は通知一覧取得オプション
 type NotificationListOptions struct {
-	MinID           int
-	MaxID           int
-	Count           int
-	Order           string // "asc" or "desc"
-	ResourceAlready bool
+	MinID    int
+	MaxID    int
+	Count    int
+	Order    string // "asc" or "desc"
+	SenderID int
 }
 
 // ToQuery はクエリパラメータに変換する
@@ -70,6 +64,9 @@ func (o *NotificationListOptions) ToQuery() url.Values {
 	}
 	if o.Order != "" {
 		q.Set("order", o.Order)
+	}
+	if o.SenderID > 0 {
+		q.Set("senderId", strconv.Itoa(o.SenderID))
 	}
 	return q
 }

--- a/packages/backlog/internal/api/project.go
+++ b/packages/backlog/internal/api/project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 
 	"github.com/yacchi/backlog-cli/packages/backlog/internal/gen/backlog"
 )
@@ -27,10 +28,26 @@ type Project struct {
 	UseDevAttributes                  bool   `json:"useDevAttributes"`
 }
 
+// ProjectListOptions はプロジェクト一覧取得オプション
+type ProjectListOptions struct {
+	// Archived が nil の場合はアーカイブ済み・未アーカイブ両方を取得する。
+	// false なら未アーカイブのみ、true ならアーカイブ済みのみ。
+	Archived *bool
+	// All は管理者向け。true の場合、参加していないプロジェクトも含めて全件取得する。
+	All bool
+}
+
 // GetProjects はプロジェクト一覧を取得する
-func (c *Client) GetProjects(ctx context.Context) ([]Project, error) {
+func (c *Client) GetProjects(ctx context.Context, opts *ProjectListOptions) ([]Project, error) {
 	query := url.Values{}
-	query.Set("archived", "false")
+	if opts != nil {
+		if opts.Archived != nil {
+			query.Set("archived", strconv.FormatBool(*opts.Archived))
+		}
+		if opts.All {
+			query.Set("all", "true")
+		}
+	}
 
 	resp, err := c.Get(ctx, "/projects", query)
 	if err != nil {

--- a/packages/backlog/internal/api/wiki.go
+++ b/packages/backlog/internal/api/wiki.go
@@ -32,10 +32,13 @@ type WikiTag struct {
 	Name string `json:"name"`
 }
 
-// GetWikis はWiki一覧を取得する
-func (c *Client) GetWikis(ctx context.Context, projectIDOrKey string) ([]Wiki, error) {
+// GetWikis はWiki一覧を取得する。keyword が空でなければ名前・本文でフィルタする。
+func (c *Client) GetWikis(ctx context.Context, projectIDOrKey, keyword string) ([]Wiki, error) {
 	query := url.Values{}
 	query.Set("projectIdOrKey", projectIDOrKey)
+	if keyword != "" {
+		query.Set("keyword", keyword)
+	}
 
 	resp, err := c.Get(ctx, "/wikis", query)
 	if err != nil {
@@ -67,10 +70,13 @@ func (c *Client) GetWiki(ctx context.Context, wikiID int) (*Wiki, error) {
 	return &wiki, nil
 }
 
-// GetWikisCount はWikiページ数を取得する
-func (c *Client) GetWikisCount(ctx context.Context, projectIDOrKey string) (int, error) {
+// GetWikisCount はWikiページ数を取得する。keyword が空でなければ名前・本文でフィルタする。
+func (c *Client) GetWikisCount(ctx context.Context, projectIDOrKey, keyword string) (int, error) {
 	query := url.Values{}
 	query.Set("projectIdOrKey", projectIDOrKey)
+	if keyword != "" {
+		query.Set("keyword", keyword)
+	}
 
 	resp, err := c.Get(ctx, "/wikis/count", query)
 	if err != nil {

--- a/packages/backlog/internal/cmd/issue/list.go
+++ b/packages/backlog/internal/cmd/issue/list.go
@@ -46,6 +46,15 @@ Examples:
   # Sort by priority
   backlog issue list --sort priority --order asc
 
+  # Filter by individual status / priority (name or ID, comma-separated)
+  backlog issue list --status 処理中,完了 --priority 高
+
+  # Filter by updated date range (YYYY-MM-DD)
+  backlog issue list --state all --updated-since 2026-04-21 --updated-until 2026-04-28
+
+  # Show only issues with attachments under a parent issue
+  backlog issue list --parent PROJ-10 --has-attachment
+
   # Fetch up to 100 issues
   backlog issue list -L 100
 
@@ -78,6 +87,23 @@ var (
 	listIssueType           string
 	listSort                string
 	listOrder               string
+	listStatus              string
+	listPriority            string
+	listResolution          string
+	listVersion             string
+	listParent              string
+	listParentChild         string
+	listID                  string
+	listHasAttachment       bool
+	listHasSharedFile       bool
+	listUpdatedSince        string
+	listUpdatedUntil        string
+	listCreatedSince        string
+	listCreatedUntil        string
+	listStartSince          string
+	listStartUntil          string
+	listDueSince            string
+	listDueUntil            string
 )
 
 func init() {
@@ -101,6 +127,23 @@ func init() {
 	listCmd.Flags().StringVarP(&listIssueType, "type", "T", "", "Filter by issue type IDs or names (e.g., 1, Bug, タスク)")
 	listCmd.Flags().StringVar(&listSort, "sort", "updated", "Sort field: created, updated, issueType, category, priority, dueDate, etc.")
 	listCmd.Flags().StringVar(&listOrder, "order", "desc", "Sort order: asc or desc")
+	listCmd.Flags().StringVar(&listStatus, "status", "", "Filter by status IDs or names (comma-separated, e.g. 処理中,完了)")
+	listCmd.Flags().StringVar(&listPriority, "priority", "", "Filter by priority IDs or names (comma-separated, e.g. 高)")
+	listCmd.Flags().StringVar(&listResolution, "resolution", "", "Filter by resolution IDs or names (comma-separated)")
+	listCmd.Flags().StringVar(&listVersion, "version", "", "Filter by affected version IDs or names (comma-separated)")
+	listCmd.Flags().StringVar(&listParent, "parent", "", "Filter by parent issue IDs or keys (comma-separated)")
+	listCmd.Flags().StringVar(&listParentChild, "parent-child", "", "Filter by parent-child relation: all, exclude-child, child, parent, none (or 0-4)")
+	listCmd.Flags().StringVar(&listID, "id", "", "Filter by issue IDs or keys (comma-separated)")
+	listCmd.Flags().BoolVar(&listHasAttachment, "has-attachment", false, "Show only issues with attachments")
+	listCmd.Flags().BoolVar(&listHasSharedFile, "has-shared-file", false, "Show only issues with shared files")
+	listCmd.Flags().StringVar(&listUpdatedSince, "updated-since", "", "Filter by updated date since (YYYY-MM-DD)")
+	listCmd.Flags().StringVar(&listUpdatedUntil, "updated-until", "", "Filter by updated date until (YYYY-MM-DD)")
+	listCmd.Flags().StringVar(&listCreatedSince, "created-since", "", "Filter by created date since (YYYY-MM-DD)")
+	listCmd.Flags().StringVar(&listCreatedUntil, "created-until", "", "Filter by created date until (YYYY-MM-DD)")
+	listCmd.Flags().StringVar(&listStartSince, "start-since", "", "Filter by start date since (YYYY-MM-DD)")
+	listCmd.Flags().StringVar(&listStartUntil, "start-until", "", "Filter by start date until (YYYY-MM-DD)")
+	listCmd.Flags().StringVar(&listDueSince, "due-since", "", "Filter by due date since (YYYY-MM-DD)")
+	listCmd.Flags().StringVar(&listDueUntil, "due-until", "", "Filter by due date until (YYYY-MM-DD)")
 }
 
 func runList(c *cobra.Command, args []string) error {
@@ -192,39 +235,122 @@ func runList(c *cobra.Command, args []string) error {
 		opts.IssueTypeIDs = issueTypeIDs
 	}
 
-	// ステータスフィルター（--state オプション）
-	switch listState {
-	case "open":
-		// Backlogのステータス: 1=未対応, 2=処理中, 3=処理済み
-		// open = 完了以外（4=完了を除く）
-		statuses, err := client.GetStatuses(ctx, strconv.Itoa(project.ID))
-		if err == nil {
-			var openStatusIDs []int
-			for _, s := range statuses {
-				// "完了" または "Closed" 以外を含める
-				if s.Name != "完了" && s.Name != "Closed" && s.Name != "Done" {
-					openStatusIDs = append(openStatusIDs, s.ID)
+	// 優先度フィルター（--priority オプション）
+	if listPriority != "" {
+		priorityIDs, err := cmdutil.ResolvePriorityIDs(ctx, client, listPriority)
+		if err != nil {
+			return fmt.Errorf("failed to resolve priorities: %w", err)
+		}
+		opts.PriorityIDs = priorityIDs
+	}
+
+	// 完了理由フィルター（--resolution オプション）
+	if listResolution != "" {
+		resolutionIDs, err := cmdutil.ResolveResolutionIDs(ctx, client, listResolution)
+		if err != nil {
+			return fmt.Errorf("failed to resolve resolutions: %w", err)
+		}
+		opts.ResolutionIDs = resolutionIDs
+	}
+
+	// 発生バージョンフィルター（--version オプション）
+	if listVersion != "" {
+		versionIDs, err := cmdutil.ResolveVersionIDs(ctx, client, projectKey, listVersion)
+		if err != nil {
+			return fmt.Errorf("failed to resolve versions: %w", err)
+		}
+		opts.VersionIDs = versionIDs
+	}
+
+	// 親課題フィルター（--parent オプション）
+	if listParent != "" {
+		parentIDs, err := cmdutil.ResolveIssueIDs(ctx, client, listParent)
+		if err != nil {
+			return fmt.Errorf("failed to resolve parent issues: %w", err)
+		}
+		opts.ParentIssueIDs = parentIDs
+	}
+
+	// 親子条件フィルター（--parent-child オプション）
+	if listParentChild != "" {
+		parentChild, err := cmdutil.ParseParentChild(listParentChild)
+		if err != nil {
+			return err
+		}
+		opts.ParentChild = parentChild
+	}
+
+	// 課題IDフィルター（--id オプション）
+	if listID != "" {
+		issueIDs, err := cmdutil.ResolveIssueIDs(ctx, client, listID)
+		if err != nil {
+			return fmt.Errorf("failed to resolve issue ids: %w", err)
+		}
+		opts.IDs = issueIDs
+	}
+
+	// 添付・共有ファイルフィルター
+	if listHasAttachment {
+		hasAttachment := true
+		opts.Attachment = &hasAttachment
+	}
+	if listHasSharedFile {
+		hasSharedFile := true
+		opts.SharedFile = &hasSharedFile
+	}
+
+	// 日付レンジフィルター
+	opts.UpdatedSince = listUpdatedSince
+	opts.UpdatedUntil = listUpdatedUntil
+	opts.CreatedSince = listCreatedSince
+	opts.CreatedUntil = listCreatedUntil
+	opts.StartDateSince = listStartSince
+	opts.StartDateUntil = listStartUntil
+	opts.DueDateSince = listDueSince
+	opts.DueDateUntil = listDueUntil
+
+	// ステータスフィルター（--status オプション、--state より優先）
+	if listStatus != "" {
+		statusIDs, err := cmdutil.ResolveStatusIDs(ctx, client, projectKey, listStatus)
+		if err != nil {
+			return fmt.Errorf("failed to resolve statuses: %w", err)
+		}
+		opts.StatusIDs = statusIDs
+	} else {
+		// ステータスフィルター（--state オプション）
+		switch listState {
+		case "open":
+			// Backlogのステータス: 1=未対応, 2=処理中, 3=処理済み
+			// open = 完了以外（4=完了を除く）
+			statuses, err := client.GetStatuses(ctx, strconv.Itoa(project.ID))
+			if err == nil {
+				var openStatusIDs []int
+				for _, s := range statuses {
+					// "完了" または "Closed" 以外を含める
+					if s.Name != "完了" && s.Name != "Closed" && s.Name != "Done" {
+						openStatusIDs = append(openStatusIDs, s.ID)
+					}
+				}
+				if len(openStatusIDs) > 0 {
+					opts.StatusIDs = openStatusIDs
 				}
 			}
-			if len(openStatusIDs) > 0 {
-				opts.StatusIDs = openStatusIDs
-			}
-		}
-	case "closed":
-		// closed = 完了のみ
-		statuses, err := client.GetStatuses(ctx, strconv.Itoa(project.ID))
-		if err == nil {
-			for _, s := range statuses {
-				if s.Name == "完了" || s.Name == "Closed" || s.Name == "Done" {
-					opts.StatusIDs = []int{s.ID}
-					break
+		case "closed":
+			// closed = 完了のみ
+			statuses, err := client.GetStatuses(ctx, strconv.Itoa(project.ID))
+			if err == nil {
+				for _, s := range statuses {
+					if s.Name == "完了" || s.Name == "Closed" || s.Name == "Done" {
+						opts.StatusIDs = []int{s.ID}
+						break
+					}
 				}
 			}
+		case "all":
+			// all = フィルターなし
+		default:
+			return fmt.Errorf("invalid state: %s (must be open, closed, or all)", listState)
 		}
-	case "all":
-		// all = フィルターなし
-	default:
-		return fmt.Errorf("invalid state: %s (must be open, closed, or all)", listState)
 	}
 
 	// 件数のみ表示

--- a/packages/backlog/internal/cmd/markdown/migrate.go
+++ b/packages/backlog/internal/cmd/markdown/migrate.go
@@ -1160,7 +1160,7 @@ func runMigrateSnapshot(cmd *cobra.Command, args []string) error {
 		existing[identityKey(item.ItemType, item.ItemKey, item.ItemID)] = true
 	}
 
-	wikis, err := client.GetWikis(cmd.Context(), meta.ProjectKey)
+	wikis, err := client.GetWikis(cmd.Context(), meta.ProjectKey, "")
 	if err != nil {
 		return fmt.Errorf("failed to get wikis: %w", err)
 	}
@@ -1568,7 +1568,7 @@ func snapshotAll(ctx context.Context, client *api.Client, projectKey string, pro
 			InputHash:  hashHex(content),
 		})
 	}
-	wikis, err := client.GetWikis(ctx, projectKey)
+	wikis, err := client.GetWikis(ctx, projectKey, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to get wikis: %w", err)
 	}

--- a/packages/backlog/internal/cmd/notification/list.go
+++ b/packages/backlog/internal/cmd/notification/list.go
@@ -21,18 +21,28 @@ var listCmd = &cobra.Command{
 Examples:
   backlog notification list
   backlog notification list --unread
-  backlog notification list --count 50`,
+  backlog notification list --count 50
+  backlog notification list --sender @me
+  backlog notification list --order asc`,
 	RunE: runList,
 }
 
 var (
 	listCount  int
 	listUnread bool
+	listOrder  string
+	listSender string
+	listMinID  int
+	listMaxID  int
 )
 
 func init() {
 	listCmd.Flags().IntVarP(&listCount, "count", "c", 20, "Number of notifications to show")
 	listCmd.Flags().BoolVar(&listUnread, "unread", false, "Show only unread notifications")
+	listCmd.Flags().StringVar(&listOrder, "order", "desc", "Sort order: asc or desc")
+	listCmd.Flags().StringVar(&listSender, "sender", "", "Filter by sender (user ID, userId, display name, or @me)")
+	listCmd.Flags().IntVar(&listMinID, "min-id", 0, "Return notifications with ID greater than this value")
+	listCmd.Flags().IntVar(&listMaxID, "max-id", 0, "Return notifications with ID less than this value")
 }
 
 func runList(c *cobra.Command, args []string) error {
@@ -43,14 +53,26 @@ func runList(c *cobra.Command, args []string) error {
 
 	profile := cfg.CurrentProfile()
 	display := cfg.Display()
+	ctx := c.Context()
 
 	// 通知一覧取得
 	opts := &api.NotificationListOptions{
 		Count: listCount,
-		Order: "desc",
+		Order: listOrder,
+		MinID: listMinID,
+		MaxID: listMaxID,
 	}
 
-	notifications, err := client.GetNotifications(c.Context(), opts)
+	// 送信者フィルター
+	if listSender != "" {
+		senderID, err := cmdutil.ResolveUserID(ctx, client, listSender)
+		if err != nil {
+			return fmt.Errorf("failed to resolve sender: %w", err)
+		}
+		opts.SenderID = senderID
+	}
+
+	notifications, err := client.GetNotifications(ctx, opts)
 	if err != nil {
 		return fmt.Errorf("failed to get notifications: %w", err)
 	}
@@ -97,7 +119,7 @@ func renderNotificationList(notifications []api.UserNotification, profile *confi
 		}
 
 		// 通知理由
-		reason := formatReason(n.Reason.ID)
+		reason := formatReason(n.Reason)
 
 		// ターゲット情報
 		var target, targetURL string

--- a/packages/backlog/internal/cmd/pr/list.go
+++ b/packages/backlog/internal/cmd/pr/list.go
@@ -29,6 +29,9 @@ Examples:
   backlog pr list --repo myrepo --state merged
   backlog pr list --repo myrepo --state all
 
+  # Filter by linked issue
+  backlog pr list --repo myrepo --issue PROJ-123
+
   # Open PR list in browser
   backlog pr list --repo myrepo --web`,
 	RunE: runList,
@@ -42,6 +45,7 @@ var (
 	listCount    bool
 	listAuthor   string
 	listAssignee string
+	listIssue    string
 )
 
 func init() {
@@ -52,6 +56,7 @@ func init() {
 	listCmd.Flags().BoolVar(&listCount, "count", false, "Show only the count of pull requests")
 	listCmd.Flags().StringVarP(&listAuthor, "author", "A", "", "Filter by author (user ID, userId, display name, or @me)")
 	listCmd.Flags().StringVarP(&listAssignee, "assignee", "a", "", "Filter by assignee (user ID, userId, display name, or @me)")
+	listCmd.Flags().StringVar(&listIssue, "issue", "", "Filter by linked issue IDs or keys (comma-separated)")
 	_ = listCmd.MarkFlagRequired("repo")
 }
 
@@ -111,6 +116,15 @@ func runList(c *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to resolve assignee: %w", err)
 		}
 		opts.AssigneeIDs = []int{assigneeID}
+	}
+
+	// 関連課題フィルター
+	if listIssue != "" {
+		issueIDs, err := cmdutil.ResolveIssueIDs(ctx, client, listIssue)
+		if err != nil {
+			return fmt.Errorf("failed to resolve issues: %w", err)
+		}
+		opts.IssueIDs = issueIDs
 	}
 
 	// 件数のみ表示

--- a/packages/backlog/internal/cmd/project/init.go
+++ b/packages/backlog/internal/cmd/project/init.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/yacchi/backlog-cli/packages/backlog/internal/api"
 	"github.com/yacchi/backlog-cli/packages/backlog/internal/cmdutil"
 	"github.com/yacchi/backlog-cli/packages/backlog/internal/config"
 	"github.com/yacchi/backlog-cli/packages/backlog/internal/ui"
@@ -58,8 +59,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 				return err
 			}
 		} else {
-			// プロジェクト一覧から選択
-			projects, err := client.GetProjects(cmd.Context())
+			// プロジェクト一覧から選択（未アーカイブのみ）
+			notArchived := false
+			projects, err := client.GetProjects(cmd.Context(), &api.ProjectListOptions{Archived: &notArchived})
 			if err != nil {
 				return fmt.Errorf("failed to get projects: %w", err)
 			}

--- a/packages/backlog/internal/cmd/project/list.go
+++ b/packages/backlog/internal/cmd/project/list.go
@@ -17,14 +17,20 @@ var listCmd = &cobra.Command{
 
 Examples:
   backlog project list
+  backlog project list --archived
+  backlog project list --all
   backlog project list -o json`,
 	RunE: runList,
 }
 
-var listArchived bool
+var (
+	listArchived bool
+	listAll      bool
+)
 
 func init() {
 	listCmd.Flags().BoolVar(&listArchived, "archived", false, "Include archived projects")
+	listCmd.Flags().BoolVar(&listAll, "all", false, "List all projects on the space (administrators only)")
 }
 
 func runList(c *cobra.Command, args []string) error {
@@ -33,7 +39,14 @@ func runList(c *cobra.Command, args []string) error {
 		return err
 	}
 
-	projects, err := client.GetProjects(c.Context())
+	opts := &api.ProjectListOptions{All: listAll}
+	// --archived 未指定時は未アーカイブのみ。指定時はアーカイブ済みも含める。
+	if !listArchived {
+		notArchived := false
+		opts.Archived = &notArchived
+	}
+
+	projects, err := client.GetProjects(c.Context(), opts)
 	if err != nil {
 		return fmt.Errorf("failed to get projects: %w", err)
 	}
@@ -41,17 +54,6 @@ func runList(c *cobra.Command, args []string) error {
 	if len(projects) == 0 {
 		fmt.Println("No projects found")
 		return nil
-	}
-
-	// アーカイブフィルター
-	if !listArchived {
-		filtered := make([]api.Project, 0)
-		for _, p := range projects {
-			if !p.Archived {
-				filtered = append(filtered, p)
-			}
-		}
-		projects = filtered
 	}
 
 	// 出力

--- a/packages/backlog/internal/cmd/watching/list.go
+++ b/packages/backlog/internal/cmd/watching/list.go
@@ -19,16 +19,27 @@ var listCmd = &cobra.Command{
 
 Examples:
   backlog watching list
-  backlog watching list --count 50`,
+  backlog watching list --count 50
+  backlog watching list --unread
+  backlog watching list --sort created --order asc
+  backlog watching list --issue PROJ-123`,
 	RunE: runList,
 }
 
 var (
-	listCount int
+	listCount  int
+	listSort   string
+	listOrder  string
+	listUnread bool
+	listIssue  string
 )
 
 func init() {
 	listCmd.Flags().IntVarP(&listCount, "count", "c", 20, "Number of items to show")
+	listCmd.Flags().StringVar(&listSort, "sort", "issueUpdated", "Sort field: created, updated, or issueUpdated")
+	listCmd.Flags().StringVar(&listOrder, "order", "desc", "Sort order: asc or desc")
+	listCmd.Flags().BoolVar(&listUnread, "unread", false, "Show only items with unread updates")
+	listCmd.Flags().StringVar(&listIssue, "issue", "", "Filter by issue IDs or keys (comma-separated)")
 }
 
 func runList(c *cobra.Command, args []string) error {
@@ -50,8 +61,23 @@ func runList(c *cobra.Command, args []string) error {
 	// ウォッチ一覧取得
 	opts := &api.WatchingListOptions{
 		Count: listCount,
-		Order: "desc",
-		Sort:  "issueUpdated",
+		Order: listOrder,
+		Sort:  listSort,
+	}
+
+	// 未読のみ
+	if listUnread {
+		unread := false
+		opts.ResourceAlreadyRead = &unread
+	}
+
+	// 課題フィルター
+	if listIssue != "" {
+		issueIDs, err := cmdutil.ResolveIssueIDs(ctx, client, listIssue)
+		if err != nil {
+			return fmt.Errorf("failed to resolve issues: %w", err)
+		}
+		opts.IssueIDs = issueIDs
 	}
 
 	watchings, err := client.GetWatchingList(ctx, myself.ID.Value, opts)

--- a/packages/backlog/internal/cmd/wiki/edit.go
+++ b/packages/backlog/internal/cmd/wiki/edit.go
@@ -114,7 +114,7 @@ func resolveWikiID(client *api.Client, ctx context.Context, projectKey, idOrName
 	}
 
 	// 名前で検索
-	wikis, err := client.GetWikis(ctx, projectKey)
+	wikis, err := client.GetWikis(ctx, projectKey, "")
 	if err != nil {
 		return 0, fmt.Errorf("failed to get wiki list: %w", err)
 	}

--- a/packages/backlog/internal/cmd/wiki/list.go
+++ b/packages/backlog/internal/cmd/wiki/list.go
@@ -19,14 +19,19 @@ var listCmd = &cobra.Command{
 Examples:
   backlog wiki list
   backlog wiki list --project MYPROJECT
+  backlog wiki list --search "release notes"
   backlog wiki list --count`,
 	RunE: runList,
 }
 
-var wikiListCount bool
+var (
+	wikiListCount  bool
+	wikiListSearch string
+)
 
 func init() {
 	listCmd.Flags().BoolVar(&wikiListCount, "count", false, "Show only the count of wiki pages")
+	listCmd.Flags().StringVarP(&wikiListSearch, "search", "S", "", "Search wiki pages by keyword (name and content)")
 }
 
 func runList(c *cobra.Command, args []string) error {
@@ -43,7 +48,17 @@ func runList(c *cobra.Command, args []string) error {
 
 	// 件数のみ表示
 	if wikiListCount {
-		count, err := client.GetWikisCount(c.Context(), projectKey)
+		// Backlog の /wikis/count は keyword を無視するため、
+		// --search 併用時は一覧を取得してクライアント側で数える。
+		if wikiListSearch != "" {
+			wikis, err := client.GetWikis(c.Context(), projectKey, wikiListSearch)
+			if err != nil {
+				return fmt.Errorf("failed to get wiki pages: %w", err)
+			}
+			fmt.Println(len(wikis))
+			return nil
+		}
+		count, err := client.GetWikisCount(c.Context(), projectKey, wikiListSearch)
 		if err != nil {
 			return fmt.Errorf("failed to get wiki count: %w", err)
 		}
@@ -51,7 +66,7 @@ func runList(c *cobra.Command, args []string) error {
 		return nil
 	}
 
-	wikis, err := client.GetWikis(c.Context(), projectKey)
+	wikis, err := client.GetWikis(c.Context(), projectKey, wikiListSearch)
 	if err != nil {
 		return fmt.Errorf("failed to get wiki pages: %w", err)
 	}

--- a/packages/backlog/internal/cmdutil/resolve.go
+++ b/packages/backlog/internal/cmdutil/resolve.go
@@ -236,6 +236,185 @@ func ResolveIssueType(ctx context.Context, client *api.Client, projectKey, input
 	return nil, nil
 }
 
+// ResolveStatusIDs resolves status IDs or exact names for a project.
+func ResolveStatusIDs(ctx context.Context, client *api.Client, projectKey, input string) ([]int, error) {
+	if projectKey == "" && hasNonNumericToken(input) {
+		return nil, errors.New("project is required to resolve status names")
+	}
+
+	statuses, err := client.GetStatuses(ctx, projectKey)
+	if err != nil {
+		return nil, err
+	}
+
+	options := make([]NamedResolverOption, len(statuses))
+	for i, status := range statuses {
+		options[i] = NamedResolverOption{
+			ID:    status.ID,
+			Label: status.Name,
+		}
+	}
+
+	return ResolveNamedIDs(input, "status", "statuses", options)
+}
+
+// ResolvePriorityIDs resolves priority IDs or exact names (space-scoped).
+func ResolvePriorityIDs(ctx context.Context, client *api.Client, input string) ([]int, error) {
+	priorities, err := client.GetPriorities(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	options := make([]NamedResolverOption, len(priorities))
+	for i, priority := range priorities {
+		options[i] = NamedResolverOption{
+			ID:    priority.ID.Value,
+			Label: priority.Name.Value,
+		}
+	}
+
+	return ResolveNamedIDs(input, "priority", "priorities", options)
+}
+
+// ResolveResolutionIDs resolves resolution IDs or exact names (space-scoped).
+func ResolveResolutionIDs(ctx context.Context, client *api.Client, input string) ([]int, error) {
+	resolutions, err := client.GetResolutions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	options := make([]NamedResolverOption, len(resolutions))
+	for i, resolution := range resolutions {
+		options[i] = NamedResolverOption{
+			ID:    resolution.ID.Value,
+			Label: resolution.Name.Value,
+		}
+	}
+
+	return ResolveNamedIDs(input, "resolution", "resolutions", options)
+}
+
+// ResolveVersionIDs resolves version IDs or exact names for a project.
+func ResolveVersionIDs(ctx context.Context, client *api.Client, projectKey, input string) ([]int, error) {
+	if projectKey == "" && hasNonNumericToken(input) {
+		return nil, errors.New("project is required to resolve version names")
+	}
+
+	versions, err := client.GetVersions(ctx, projectKey)
+	if err != nil {
+		return nil, err
+	}
+
+	options := make([]NamedResolverOption, len(versions))
+	for i, version := range versions {
+		options[i] = NamedResolverOption{
+			ID:    version.ID,
+			Label: version.Name,
+		}
+	}
+
+	return ResolveNamedIDs(input, "version", "versions", options)
+}
+
+// ResolveIssueIDs resolves a comma-separated list of issue IDs or issue keys
+// (e.g. "123,PROJ-45") into numeric issue IDs.
+func ResolveIssueIDs(ctx context.Context, client *api.Client, input string) ([]int, error) {
+	parts := strings.Split(input, ",")
+	ids := make([]int, 0, len(parts))
+	for _, part := range parts {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		if id, err := strconv.Atoi(value); err == nil {
+			ids = append(ids, id)
+			continue
+		}
+		issue, err := client.GetIssue(ctx, value)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve issue %q: %w", value, err)
+		}
+		if !issue.ID.IsSet() {
+			return nil, fmt.Errorf("issue %q has no ID", value)
+		}
+		ids = append(ids, issue.ID.Value)
+	}
+	return ids, nil
+}
+
+// ParseParentChild parses a parent-child filter value into the Backlog API
+// parentChild parameter (0: all, 1: exclude child, 2: child only,
+// 3: neither parent nor child, 4: parent only).
+func ParseParentChild(input string) (int, error) {
+	value := strings.TrimSpace(input)
+	if value == "" {
+		return 0, nil
+	}
+	if n, err := strconv.Atoi(value); err == nil {
+		if n < 0 || n > 4 {
+			return 0, fmt.Errorf("invalid parent-child value: %d (must be 0-4)", n)
+		}
+		return n, nil
+	}
+	switch strings.ToLower(value) {
+	case "all":
+		return 0, nil
+	case "exclude-child", "not-child":
+		return 1, nil
+	case "child":
+		return 2, nil
+	case "none", "neither":
+		return 3, nil
+	case "parent":
+		return 4, nil
+	default:
+		return 0, fmt.Errorf("invalid parent-child value: %q (must be all, exclude-child, child, parent, none, or 0-4)", value)
+	}
+}
+
+// ResolveUserID resolves a space-level user using @me, numeric ID, userId, or
+// display name. Unlike ResolveProjectUserID this is not scoped to a project, so
+// it is suitable for resources like notifications that are not project-bound.
+func ResolveUserID(ctx context.Context, client *api.Client, input string) (int, error) {
+	value := strings.TrimSpace(input)
+	if value == "" {
+		return 0, fmt.Errorf("user value cannot be empty")
+	}
+	if value == "@me" {
+		me, err := client.GetCurrentUser(ctx)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get current user: %w", err)
+		}
+		return me.ID.Value, nil
+	}
+	if id, err := strconv.Atoi(value); err == nil {
+		return id, nil
+	}
+
+	users, err := client.GetUsers(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	options := make([]NamedResolverOption, len(users))
+	for i, user := range users {
+		var aliases []string
+		description := user.Name.Value
+		if user.UserId.Value != "" {
+			aliases = []string{user.UserId.Value}
+			description = fmt.Sprintf("%s (%s)", user.Name.Value, user.UserId.Value)
+		}
+		options[i] = NamedResolverOption{
+			ID:          user.ID.Value,
+			Label:       user.Name.Value,
+			Aliases:     aliases,
+			Description: description,
+		}
+	}
+
+	return ResolveNamedID(value, "user", "users", options)
+}
+
 // ResolveProjectUserID resolves a project user using @me, numeric ID, userId, or display name.
 func ResolveProjectUserID(ctx context.Context, client *api.Client, projectKey, input string) (int, error) {
 	return resolveProjectUserID(ctx, client, projectKey, input, "user", "users")

--- a/packages/backlog/internal/cmdutil/resolve_test.go
+++ b/packages/backlog/internal/cmdutil/resolve_test.go
@@ -66,6 +66,49 @@ func TestResolveNamedIDReportsAmbiguousMatches(t *testing.T) {
 	}
 }
 
+func TestParseParentChild(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{name: "empty", input: "", want: 0},
+		{name: "all", input: "all", want: 0},
+		{name: "exclude-child", input: "exclude-child", want: 1},
+		{name: "not-child alias", input: "not-child", want: 1},
+		{name: "child", input: "child", want: 2},
+		{name: "none", input: "none", want: 3},
+		{name: "neither alias", input: "neither", want: 3},
+		{name: "parent", input: "parent", want: 4},
+		{name: "uppercase", input: "PARENT", want: 4},
+		{name: "numeric 0", input: "0", want: 0},
+		{name: "numeric 4", input: "4", want: 4},
+		{name: "numeric with spaces", input: " 2 ", want: 2},
+		{name: "numeric out of range", input: "5", wantErr: true},
+		{name: "negative", input: "-1", wantErr: true},
+		{name: "invalid string", input: "foo", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseParentChild(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseParentChild(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseParentChild(%q) unexpected error: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("ParseParentChild(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDescribeProjectUser(t *testing.T) {
 	if got := describeProjectUser(api.User{ID: 10, UserID: "alice", Name: "Alice"}); got != "Alice (alice)" {
 		t.Fatalf("describeProjectUser() = %q, want %q", got, "Alice (alice)")

--- a/packages/backlog/internal/gen/backlog/oas_client_gen.go
+++ b/packages/backlog/internal/gen/backlog/oas_client_gen.go
@@ -5151,6 +5151,110 @@ func (c *Client) sendGetIssuesCount(ctx context.Context, params GetIssuesCountPa
 		}
 	}
 	{
+		// Encode "issueTypeId[]" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "issueTypeId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.IssueTypeId != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.IssueTypeId {
+						if err := func() error {
+							return e.EncodeValue(conv.IntToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "categoryId[]" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "categoryId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.CategoryId != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.CategoryId {
+						if err := func() error {
+							return e.EncodeValue(conv.IntToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "versionId[]" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "versionId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.VersionId != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.VersionId {
+						if err := func() error {
+							return e.EncodeValue(conv.IntToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "milestoneId[]" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "milestoneId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.MilestoneId != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.MilestoneId {
+						if err := func() error {
+							return e.EncodeValue(conv.IntToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
 		// Encode "statusId[]" parameter.
 		cfg := uri.QueryParameterEncodingConfig{
 			Name:    "statusId[]",
@@ -5162,6 +5266,366 @@ func (c *Client) sendGetIssuesCount(ctx context.Context, params GetIssuesCountPa
 			if params.StatusId != nil {
 				return e.EncodeArray(func(e uri.Encoder) error {
 					for i, item := range params.StatusId {
+						if err := func() error {
+							return e.EncodeValue(conv.IntToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "priorityId[]" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "priorityId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.PriorityId != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.PriorityId {
+						if err := func() error {
+							return e.EncodeValue(conv.IntToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "assigneeId[]" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "assigneeId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.AssigneeId != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.AssigneeId {
+						if err := func() error {
+							return e.EncodeValue(conv.IntToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "createdUserId[]" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "createdUserId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.CreatedUserId != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.CreatedUserId {
+						if err := func() error {
+							return e.EncodeValue(conv.IntToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "resolutionId[]" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "resolutionId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.ResolutionId != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.ResolutionId {
+						if err := func() error {
+							return e.EncodeValue(conv.IntToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "parentChild" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "parentChild",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.ParentChild.Get(); ok {
+				return e.EncodeValue(conv.IntToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "attachment" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "attachment",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Attachment.Get(); ok {
+				return e.EncodeValue(conv.BoolToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "sharedFile" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "sharedFile",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.SharedFile.Get(); ok {
+				return e.EncodeValue(conv.BoolToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "keyword" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "keyword",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.Keyword.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "createdSince" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "createdSince",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.CreatedSince.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "createdUntil" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "createdUntil",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.CreatedUntil.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "updatedSince" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "updatedSince",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.UpdatedSince.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "updatedUntil" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "updatedUntil",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.UpdatedUntil.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "startDateSince" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "startDateSince",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.StartDateSince.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "startDateUntil" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "startDateUntil",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.StartDateUntil.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "dueDateSince" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "dueDateSince",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.DueDateSince.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "dueDateUntil" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "dueDateUntil",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if val, ok := params.DueDateUntil.Get(); ok {
+				return e.EncodeValue(conv.StringToString(val))
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "id[]" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "id[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.ID != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.ID {
+						if err := func() error {
+							return e.EncodeValue(conv.IntToString(item))
+						}(); err != nil {
+							return errors.Wrapf(err, "[%d]", i)
+						}
+					}
+					return nil
+				})
+			}
+			return nil
+		}); err != nil {
+			return res, errors.Wrap(err, "encode query")
+		}
+	}
+	{
+		// Encode "parentIssueId[]" parameter.
+		cfg := uri.QueryParameterEncodingConfig{
+			Name:    "parentIssueId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.EncodeParam(cfg, func(e uri.Encoder) error {
+			if params.ParentIssueId != nil {
+				return e.EncodeArray(func(e uri.Encoder) error {
+					for i, item := range params.ParentIssueId {
 						if err := func() error {
 							return e.EncodeValue(conv.IntToString(item))
 						}(); err != nil {

--- a/packages/backlog/internal/gen/backlog/oas_handlers_gen.go
+++ b/packages/backlog/internal/gen/backlog/oas_handlers_gen.go
@@ -6098,9 +6098,97 @@ func (s *Server) handleGetIssuesCountRequest(args [0]string, argsEscaped bool, w
 					In:   "query",
 				}: params.ProjectId,
 				{
+					Name: "issueTypeId[]",
+					In:   "query",
+				}: params.IssueTypeId,
+				{
+					Name: "categoryId[]",
+					In:   "query",
+				}: params.CategoryId,
+				{
+					Name: "versionId[]",
+					In:   "query",
+				}: params.VersionId,
+				{
+					Name: "milestoneId[]",
+					In:   "query",
+				}: params.MilestoneId,
+				{
 					Name: "statusId[]",
 					In:   "query",
 				}: params.StatusId,
+				{
+					Name: "priorityId[]",
+					In:   "query",
+				}: params.PriorityId,
+				{
+					Name: "assigneeId[]",
+					In:   "query",
+				}: params.AssigneeId,
+				{
+					Name: "createdUserId[]",
+					In:   "query",
+				}: params.CreatedUserId,
+				{
+					Name: "resolutionId[]",
+					In:   "query",
+				}: params.ResolutionId,
+				{
+					Name: "parentChild",
+					In:   "query",
+				}: params.ParentChild,
+				{
+					Name: "attachment",
+					In:   "query",
+				}: params.Attachment,
+				{
+					Name: "sharedFile",
+					In:   "query",
+				}: params.SharedFile,
+				{
+					Name: "keyword",
+					In:   "query",
+				}: params.Keyword,
+				{
+					Name: "createdSince",
+					In:   "query",
+				}: params.CreatedSince,
+				{
+					Name: "createdUntil",
+					In:   "query",
+				}: params.CreatedUntil,
+				{
+					Name: "updatedSince",
+					In:   "query",
+				}: params.UpdatedSince,
+				{
+					Name: "updatedUntil",
+					In:   "query",
+				}: params.UpdatedUntil,
+				{
+					Name: "startDateSince",
+					In:   "query",
+				}: params.StartDateSince,
+				{
+					Name: "startDateUntil",
+					In:   "query",
+				}: params.StartDateUntil,
+				{
+					Name: "dueDateSince",
+					In:   "query",
+				}: params.DueDateSince,
+				{
+					Name: "dueDateUntil",
+					In:   "query",
+				}: params.DueDateUntil,
+				{
+					Name: "id[]",
+					In:   "query",
+				}: params.ID,
+				{
+					Name: "parentIssueId[]",
+					In:   "query",
+				}: params.ParentIssueId,
 			},
 			Raw: r,
 		}

--- a/packages/backlog/internal/gen/backlog/oas_parameters_gen.go
+++ b/packages/backlog/internal/gen/backlog/oas_parameters_gen.go
@@ -3785,8 +3785,30 @@ func decodeGetIssuesParams(args [0]string, argsEscaped bool, r *http.Request) (p
 
 // GetIssuesCountParams is parameters of getIssuesCount operation.
 type GetIssuesCountParams struct {
-	ProjectId []int `json:",omitempty"`
-	StatusId  []int `json:",omitempty"`
+	ProjectId      []int     `json:",omitempty"`
+	IssueTypeId    []int     `json:",omitempty"`
+	CategoryId     []int     `json:",omitempty"`
+	VersionId      []int     `json:",omitempty"`
+	MilestoneId    []int     `json:",omitempty"`
+	StatusId       []int     `json:",omitempty"`
+	PriorityId     []int     `json:",omitempty"`
+	AssigneeId     []int     `json:",omitempty"`
+	CreatedUserId  []int     `json:",omitempty"`
+	ResolutionId   []int     `json:",omitempty"`
+	ParentChild    OptInt    `json:",omitempty,omitzero"`
+	Attachment     OptBool   `json:",omitempty,omitzero"`
+	SharedFile     OptBool   `json:",omitempty,omitzero"`
+	Keyword        OptString `json:",omitempty,omitzero"`
+	CreatedSince   OptString `json:",omitempty,omitzero"`
+	CreatedUntil   OptString `json:",omitempty,omitzero"`
+	UpdatedSince   OptString `json:",omitempty,omitzero"`
+	UpdatedUntil   OptString `json:",omitempty,omitzero"`
+	StartDateSince OptString `json:",omitempty,omitzero"`
+	StartDateUntil OptString `json:",omitempty,omitzero"`
+	DueDateSince   OptString `json:",omitempty,omitzero"`
+	DueDateUntil   OptString `json:",omitempty,omitzero"`
+	ID             []int     `json:",omitempty"`
+	ParentIssueId  []int     `json:",omitempty"`
 }
 
 func unpackGetIssuesCountParams(packed middleware.Parameters) (params GetIssuesCountParams) {
@@ -3801,11 +3823,209 @@ func unpackGetIssuesCountParams(packed middleware.Parameters) (params GetIssuesC
 	}
 	{
 		key := middleware.ParameterKey{
+			Name: "issueTypeId[]",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.IssueTypeId = v.([]int)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "categoryId[]",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.CategoryId = v.([]int)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "versionId[]",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.VersionId = v.([]int)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "milestoneId[]",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.MilestoneId = v.([]int)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
 			Name: "statusId[]",
 			In:   "query",
 		}
 		if v, ok := packed[key]; ok {
 			params.StatusId = v.([]int)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "priorityId[]",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.PriorityId = v.([]int)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "assigneeId[]",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.AssigneeId = v.([]int)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "createdUserId[]",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.CreatedUserId = v.([]int)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "resolutionId[]",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.ResolutionId = v.([]int)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "parentChild",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.ParentChild = v.(OptInt)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "attachment",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Attachment = v.(OptBool)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "sharedFile",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.SharedFile = v.(OptBool)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "keyword",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.Keyword = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "createdSince",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.CreatedSince = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "createdUntil",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.CreatedUntil = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "updatedSince",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.UpdatedSince = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "updatedUntil",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.UpdatedUntil = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "startDateSince",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.StartDateSince = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "startDateUntil",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.StartDateUntil = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "dueDateSince",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.DueDateSince = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "dueDateUntil",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.DueDateUntil = v.(OptString)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "id[]",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.ID = v.([]int)
+		}
+	}
+	{
+		key := middleware.ParameterKey{
+			Name: "parentIssueId[]",
+			In:   "query",
+		}
+		if v, ok := packed[key]; ok {
+			params.ParentIssueId = v.([]int)
 		}
 	}
 	return params
@@ -3856,6 +4076,178 @@ func decodeGetIssuesCountParams(args [0]string, argsEscaped bool, r *http.Reques
 			Err:  err,
 		}
 	}
+	// Decode query: issueTypeId[].
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "issueTypeId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotIssueTypeIdVal int
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToInt(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotIssueTypeIdVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.IssueTypeId = append(params.IssueTypeId, paramsDotIssueTypeIdVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "issueTypeId[]",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: categoryId[].
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "categoryId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotCategoryIdVal int
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToInt(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotCategoryIdVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.CategoryId = append(params.CategoryId, paramsDotCategoryIdVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "categoryId[]",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: versionId[].
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "versionId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotVersionIdVal int
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToInt(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotVersionIdVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.VersionId = append(params.VersionId, paramsDotVersionIdVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "versionId[]",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: milestoneId[].
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "milestoneId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotMilestoneIdVal int
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToInt(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotMilestoneIdVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.MilestoneId = append(params.MilestoneId, paramsDotMilestoneIdVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "milestoneId[]",
+			In:   "query",
+			Err:  err,
+		}
+	}
 	// Decode query: statusId[].
 	if err := func() error {
 		cfg := uri.QueryParameterDecodingConfig{
@@ -3895,6 +4287,756 @@ func decodeGetIssuesCountParams(args [0]string, argsEscaped bool, r *http.Reques
 	}(); err != nil {
 		return params, &ogenerrors.DecodeParamError{
 			Name: "statusId[]",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: priorityId[].
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "priorityId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotPriorityIdVal int
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToInt(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotPriorityIdVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.PriorityId = append(params.PriorityId, paramsDotPriorityIdVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "priorityId[]",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: assigneeId[].
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "assigneeId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotAssigneeIdVal int
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToInt(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotAssigneeIdVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.AssigneeId = append(params.AssigneeId, paramsDotAssigneeIdVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "assigneeId[]",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: createdUserId[].
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "createdUserId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotCreatedUserIdVal int
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToInt(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotCreatedUserIdVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.CreatedUserId = append(params.CreatedUserId, paramsDotCreatedUserIdVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "createdUserId[]",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: resolutionId[].
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "resolutionId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotResolutionIdVal int
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToInt(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotResolutionIdVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.ResolutionId = append(params.ResolutionId, paramsDotResolutionIdVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "resolutionId[]",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: parentChild.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "parentChild",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotParentChildVal int
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToInt(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotParentChildVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.ParentChild.SetTo(paramsDotParentChildVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "parentChild",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: attachment.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "attachment",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotAttachmentVal bool
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToBool(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotAttachmentVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Attachment.SetTo(paramsDotAttachmentVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "attachment",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: sharedFile.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "sharedFile",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotSharedFileVal bool
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToBool(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotSharedFileVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.SharedFile.SetTo(paramsDotSharedFileVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "sharedFile",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: keyword.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "keyword",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotKeywordVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotKeywordVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.Keyword.SetTo(paramsDotKeywordVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "keyword",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: createdSince.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "createdSince",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotCreatedSinceVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotCreatedSinceVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.CreatedSince.SetTo(paramsDotCreatedSinceVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "createdSince",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: createdUntil.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "createdUntil",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotCreatedUntilVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotCreatedUntilVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.CreatedUntil.SetTo(paramsDotCreatedUntilVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "createdUntil",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: updatedSince.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "updatedSince",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotUpdatedSinceVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotUpdatedSinceVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.UpdatedSince.SetTo(paramsDotUpdatedSinceVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "updatedSince",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: updatedUntil.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "updatedUntil",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotUpdatedUntilVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotUpdatedUntilVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.UpdatedUntil.SetTo(paramsDotUpdatedUntilVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "updatedUntil",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: startDateSince.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "startDateSince",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotStartDateSinceVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotStartDateSinceVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.StartDateSince.SetTo(paramsDotStartDateSinceVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "startDateSince",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: startDateUntil.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "startDateUntil",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotStartDateUntilVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotStartDateUntilVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.StartDateUntil.SetTo(paramsDotStartDateUntilVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "startDateUntil",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: dueDateSince.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "dueDateSince",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotDueDateSinceVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotDueDateSinceVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.DueDateSince.SetTo(paramsDotDueDateSinceVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "dueDateSince",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: dueDateUntil.
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "dueDateUntil",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				var paramsDotDueDateUntilVal string
+				if err := func() error {
+					val, err := d.DecodeValue()
+					if err != nil {
+						return err
+					}
+
+					c, err := conv.ToString(val)
+					if err != nil {
+						return err
+					}
+
+					paramsDotDueDateUntilVal = c
+					return nil
+				}(); err != nil {
+					return err
+				}
+				params.DueDateUntil.SetTo(paramsDotDueDateUntilVal)
+				return nil
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "dueDateUntil",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: id[].
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "id[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotIDVal int
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToInt(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotIDVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.ID = append(params.ID, paramsDotIDVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "id[]",
+			In:   "query",
+			Err:  err,
+		}
+	}
+	// Decode query: parentIssueId[].
+	if err := func() error {
+		cfg := uri.QueryParameterDecodingConfig{
+			Name:    "parentIssueId[]",
+			Style:   uri.QueryStyleForm,
+			Explode: true,
+		}
+
+		if err := q.HasParam(cfg); err == nil {
+			if err := q.DecodeParam(cfg, func(d uri.Decoder) error {
+				return d.DecodeArray(func(d uri.Decoder) error {
+					var paramsDotParentIssueIdVal int
+					if err := func() error {
+						val, err := d.DecodeValue()
+						if err != nil {
+							return err
+						}
+
+						c, err := conv.ToInt(val)
+						if err != nil {
+							return err
+						}
+
+						paramsDotParentIssueIdVal = c
+						return nil
+					}(); err != nil {
+						return err
+					}
+					params.ParentIssueId = append(params.ParentIssueId, paramsDotParentIssueIdVal)
+					return nil
+				})
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "parentIssueId[]",
 			In:   "query",
 			Err:  err,
 		}


### PR DESCRIPTION
## 概要

`issue list` をはじめとする各 `list` コマンドのフィルタフラグを、Backlog API が受け付けるクエリパラメータと全網羅になるよう拡充する。Closes #18。

調査の過程で issue 以外のコマンド（wiki/pr/watching/notification/project）にも同種のフィルタ不足や潜在バグが見つかったため、まとめて対応した。

## 変更内容

### issue list（#18 本体）
- 日付レンジ4ペア: `--updated-since/until`, `--created-since/until`, `--start-since/until`, `--due-since/until`
- `--status` / `--priority` / `--resolution` / `--version` / `--parent` / `--id`（name または ID のカンマ区切り）
- `--parent-child` / `--has-attachment` / `--has-shared-file`
- `--count` も全フィルタを反映するよう `/issues/count` のパラメータを拡充

### その他の list コマンド
- **wiki list**: `--search`（keyword）。count は API が keyword 非対応のため一覧から算出
- **pr list**: `--issue`（リンク課題、key/ID 対応）
- **watching list**: `--sort` / `--order` / `--unread` / `--issue`
- **notification list**: `--order` / `--sender` / `--min-id` / `--max-id`
- **project list**: `--archived` を API パラメータ方式に修正（従来は機能せず）＋管理者向け `--all`

### 既存バグ修正
- `notification list` が API の `reason`（整数）を object としてデコードしようとして必ず失敗していた問題を修正
- `project list --archived` がアーカイブ済みプロジェクトを取得できていなかった問題を修正

## 動作確認

実 Backlog スペースで全フラグを検証済み（件数の整合性・JSON 実データ・raw API との一致・エラーハンドリング）。`make build` / `make test` / `make lint`（変更パッケージ）すべてパス。

🤖 Generated with [Claude Code](https://claude.com/claude-code)