### PR TITLE
feat(action): CLIインストール用composite actionを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,3 +125,23 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # GitHub Action (composite) を `@vN` の浮動メジャータグで参照できるようにする。
+      # 安定版リリースが成功したら v{major} を今回のコミットへ貼り替える。
+      # プレリリース（例 0.28.0-rc.1）では浮動タグを動かさない。
+      - name: Update floating major tag for the Action
+        if: steps.check_release.outputs.exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [[ "${VERSION}" == *-* ]]; then
+            echo "Pre-release (${VERSION}); skipping floating tag update."
+            exit 0
+          fi
+          MAJOR="v${VERSION%%.*}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # HEAD はリリースタグ v${VERSION} と同じコミット（version.txt を更新したコミット）
+          git tag -f "${MAJOR}" -m "Update ${MAJOR} to v${VERSION}"
+          git push -f origin "refs/tags/${MAJOR}"
+          echo "Moved floating tag ${MAJOR} -> v${VERSION}"

--- a/.github/workflows/test-setup-action.yml
+++ b/.github/workflows/test-setup-action.yml
@@ -1,0 +1,34 @@
+name: Test Setup Action
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'action.yml'
+      - '.github/workflows/test-setup-action.yml'
+  pull_request:
+    paths:
+      - 'action.yml'
+      - '.github/workflows/test-setup-action.yml'
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install backlog CLI via action
+        id: setup
+        uses: ./
+
+      - name: Verify it is on PATH and runs
+        shell: bash
+        run: |
+          echo "Installed version: ${{ steps.setup.outputs.version }}"
+          echo "Installed path:    ${{ steps.setup.outputs.path }}"
+          backlog version

--- a/README.md
+++ b/README.md
@@ -12,6 +12,41 @@ Backlog をターミナルから操作するためのコマンドラインツー
 go install github.com/yacchi/backlog-cli/cmd/backlog@latest
 ```
 
+### GitHub Actions でインストール
+
+ワークフローからは、このリポジトリが提供するセットアップアクション（composite action）で `backlog` を
+導入できます。ビルド済みバイナリをダウンロードするだけなので高速で、Go のセットアップは不要です。
+対応: Linux / macOS / Windows、`amd64` / `arm64`。
+
+```yaml
+- uses: yacchi/backlog-cli@v0.27.0
+  with:
+    version: 0.27.0        # 省略時は最新リリース ("latest")
+- run: backlog issue list --json
+  env:
+    BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+    BACKLOG_SPACE: your-space
+    BACKLOG_DOMAIN: backlog.jp        # backlog.jp または backlog.com
+    BACKLOG_ACCESS_MODE: read-only    # 任意: 書き込み系コマンドを無効化
+```
+
+**inputs**
+
+| 名前              | デフォルト             | 説明                                                       |
+|-----------------|-------------------|----------------------------------------------------------|
+| `version`       | `latest`          | インストールするバージョン。`0.27.0` / `v0.27.0` / `latest` を受け付ける。 |
+| `github-token`  | `${{ github.token }}` | リリース情報の取得・アセットのダウンロードに使うトークン。                           |
+| `verify-checksum` | `true`            | `checksums.txt` によるダウンロードアーカイブの検証を行うか。                   |
+
+**outputs**: `version`（インストールしたバージョン）、`path`（`backlog` 実行ファイルの絶対パス）。
+
+**バージョン参照**: 特定バージョンに固定したい場合は `@v0.27.0`、最新のメジャー系列を追従したい場合は
+浮動タグ `@v0` を使えます（`@v0` は安定版リリースのたびに最新へ更新されます）。
+
+```yaml
+- uses: yacchi/backlog-cli@v0        # v0 系列の最新に追従
+```
+
 ### Claude Code プラグイン
 
 [Claude Code](https://claude.com/claude-code) から Backlog を操作するためのプラグインも提供しています。

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,130 @@
+name: 'Setup Backlog CLI'
+description: 'Install the backlog CLI (GitHub CLI-compatible command-line tool for Backlog) and add it to PATH.'
+author: 'yacchi'
+branding:
+  icon: 'terminal'
+  color: 'green'
+
+inputs:
+  version:
+    description: 'Version of backlog CLI to install (e.g. "0.27.0" or "v0.27.0"). Defaults to the latest release.'
+    required: false
+    default: 'latest'
+  github-token:
+    description: 'Token used to query the GitHub API for release metadata and download assets. Defaults to the workflow token.'
+    required: false
+    default: ${{ github.token }}
+  verify-checksum:
+    description: 'Verify the downloaded archive against checksums.txt from the release.'
+    required: false
+    default: 'true'
+
+outputs:
+  version:
+    description: 'The version of backlog CLI that was installed (without the leading "v").'
+    value: ${{ steps.install.outputs.version }}
+  path:
+    description: 'Absolute path to the installed backlog executable.'
+    value: ${{ steps.install.outputs.path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: install
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        INPUT_VERSION: ${{ inputs.version }}
+        INPUT_VERIFY_CHECKSUM: ${{ inputs.verify-checksum }}
+      run: |
+        set -euo pipefail
+
+        REPO="yacchi/backlog-cli"
+        API="https://api.github.com/repos/${REPO}"
+
+        # --- Resolve version ---------------------------------------------------
+        VERSION="${INPUT_VERSION}"
+        if [ "${VERSION}" = "latest" ] || [ -z "${VERSION}" ]; then
+          echo "Resolving latest release of ${REPO}..."
+          TAG="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${API}/releases/latest" \
+            | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+          if [ -z "${TAG}" ]; then
+            echo "::error::Failed to resolve the latest release tag." >&2
+            exit 1
+          fi
+        else
+          # Accept both "0.27.0" and "v0.27.0"
+          TAG="v${VERSION#v}"
+        fi
+        VERSION="${TAG#v}"
+        echo "Installing backlog CLI ${TAG}"
+
+        # --- Detect OS / arch --------------------------------------------------
+        UNAME_S="$(uname -s)"
+        case "${UNAME_S}" in
+          Linux*)   OS="linux";   EXT="tar.gz"; BIN="backlog" ;;
+          Darwin*)  OS="darwin";  EXT="tar.gz"; BIN="backlog" ;;
+          MINGW*|MSYS*|CYGWIN*) OS="windows"; EXT="zip"; BIN="backlog.exe" ;;
+          *) echo "::error::Unsupported OS: ${UNAME_S}" >&2; exit 1 ;;
+        esac
+
+        UNAME_M="$(uname -m)"
+        case "${UNAME_M}" in
+          x86_64|amd64)   ARCH="amd64" ;;
+          arm64|aarch64)  ARCH="arm64" ;;
+          *) echo "::error::Unsupported architecture: ${UNAME_M}" >&2; exit 1 ;;
+        esac
+
+        ASSET="backlog-cli_${VERSION}_${OS}_${ARCH}.${EXT}"
+        BASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+
+        WORKDIR="$(mktemp -d)"
+        cd "${WORKDIR}"
+
+        echo "Downloading ${ASSET}..."
+        curl -fsSL -o "${ASSET}" "${BASE_URL}/${ASSET}"
+
+        # --- Verify checksum ---------------------------------------------------
+        if [ "${INPUT_VERIFY_CHECKSUM}" = "true" ]; then
+          echo "Verifying checksum..."
+          curl -fsSL -o checksums.txt "${BASE_URL}/checksums.txt"
+          EXPECTED="$(grep " ${ASSET}\$" checksums.txt | awk '{print $1}')"
+          if [ -z "${EXPECTED}" ]; then
+            echo "::error::Checksum for ${ASSET} not found in checksums.txt" >&2
+            exit 1
+          fi
+          if command -v sha256sum >/dev/null 2>&1; then
+            ACTUAL="$(sha256sum "${ASSET}" | awk '{print $1}')"
+          elif command -v shasum >/dev/null 2>&1; then
+            ACTUAL="$(shasum -a 256 "${ASSET}" | awk '{print $1}')"
+          else
+            echo "::warning::No sha256 tool available; skipping checksum verification."
+            ACTUAL="${EXPECTED}"
+          fi
+          if [ "${ACTUAL}" != "${EXPECTED}" ]; then
+            echo "::error::Checksum mismatch for ${ASSET} (expected ${EXPECTED}, got ${ACTUAL})" >&2
+            exit 1
+          fi
+        fi
+
+        # --- Extract -----------------------------------------------------------
+        if [ "${EXT}" = "zip" ]; then
+          unzip -q "${ASSET}"
+        else
+          tar -xzf "${ASSET}"
+        fi
+
+        # --- Install into a stable, PATH-exported directory --------------------
+        INSTALL_DIR="${RUNNER_TEMP:-${WORKDIR}}/backlog-cli-bin"
+        mkdir -p "${INSTALL_DIR}"
+        install -m 0755 "${BIN}" "${INSTALL_DIR}/${BIN}" 2>/dev/null || {
+          cp "${BIN}" "${INSTALL_DIR}/${BIN}"
+          chmod +x "${INSTALL_DIR}/${BIN}"
+        }
+        echo "${INSTALL_DIR}" >> "${GITHUB_PATH}"
+
+        echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+        echo "path=${INSTALL_DIR}/${BIN}" >> "${GITHUB_OUTPUT}"
+        echo "Installed backlog CLI ${VERSION} to ${INSTALL_DIR}/${BIN}"

--- a/action.yml
+++ b/action.yml
@@ -46,10 +46,13 @@ runs:
         VERSION="${INPUT_VERSION}"
         if [ "${VERSION}" = "latest" ] || [ -z "${VERSION}" ]; then
           echo "Resolving latest release of ${REPO}..."
-          TAG="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
+          # curl 出力を一旦変数へ格納してから解析する。
+          # `curl | grep -m1` のように下流が早期にパイプを閉じると、pipefail 下で
+          # curl が SIGPIPE により exit 23 となりスクリプトが中断するため。
+          RESP="$(curl -fsSL -H "Authorization: Bearer ${GH_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "${API}/releases/latest" \
-            | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')"
+            "${API}/releases/latest")"
+          TAG="$(sed -nE '/"tag_name"/{s/.*"tag_name": *"([^"]+)".*/\1/p;q;}' <<< "${RESP}")"
           if [ -z "${TAG}" ]; then
             echo "::error::Failed to resolve the latest release tag." >&2
             exit 1


### PR DESCRIPTION
## 概要

このリポジトリから `backlog` CLI を再利用しやすい形で配布するため、ルートに composite action を追加します。利用者は次のようにワークフローから導入できます。

```yaml
- uses: yacchi/backlog-cli@v0        # または @v0.27.0
  with:
    version: 0.27.0                  # 省略時は latest
- run: backlog issue list --json
  env:
    BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
    BACKLOG_SPACE: your-space
    BACKLOG_DOMAIN: backlog.jp
```

## 変更内容

- **`action.yml`（ルート配置）**: GitHub Releases のビルド済みバイナリを OS/arch 判定でダウンロードし PATH に追加する composite action。checksums.txt 検証付き。Linux / macOS / Windows・amd64 / arm64 対応。inputs: `version` / `github-token` / `verify-checksum`、outputs: `version` / `path`。
- **`release.yml`**: 安定版リリース成功後に浮動メジャータグ `v0` を当該コミットへ更新（プレリリースはスキップ）。`uses: ...@v0` で系列追従が可能に。
- **`test-setup-action.yml`**: Ubuntu / macOS / Windows マトリクスで action を実行し `backlog version` を検証する CI。
- **README.md**: GitHub Actions でのインストール手順・inputs/outputs・バージョン参照方法を追記。

## 動作確認

- ローカルで action のコアロジックを E2E 実行（DL → checksum 一致 → `backlog version 0.27.0`）。
- 実リリース `v0.27.0` のアセット命名 `backlog-cli_{version}_{os}_{arch}` と一致を確認。

## マージ後の作業（オーナー）

- **Marketplace 公開**: action.yml を含む次回リリース（例 `v0.28.0`）の編集画面で "Publish this Action to the GitHub Marketplace" にチェック。
- `@v0` 浮動タグは次回の安定版リリースで自動作成されます（現行 `v0.27.0` タグは action.yml を含まないため、そこには貼りません）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)