### PR TITLE
feat(action): 認証情報の入力を追加しCI設定を集約

### DIFF
--- a/.github/workflows/test-setup-action.yml
+++ b/.github/workflows/test-setup-action.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install backlog CLI via action
         id: setup
         uses: ./
+        with:
+          space: test-space
+          domain: backlog.jp
 
       - name: Verify it is on PATH and runs
         shell: bash
@@ -32,3 +35,10 @@ jobs:
           echo "Installed version: ${{ steps.setup.outputs.version }}"
           echo "Installed path:    ${{ steps.setup.outputs.path }}"
           backlog version
+
+      - name: Verify credential inputs are exported to env
+        shell: bash
+        run: |
+          test "${BACKLOG_SPACE}" = "test-space" || { echo "BACKLOG_SPACE not exported"; exit 1; }
+          test "${BACKLOG_DOMAIN}" = "backlog.jp" || { echo "BACKLOG_DOMAIN not exported"; exit 1; }
+          echo "Credential inputs exported correctly."

--- a/README.md
+++ b/README.md
@@ -18,33 +18,72 @@ go install github.com/yacchi/backlog-cli/cmd/backlog@latest
 導入できます。ビルド済みバイナリをダウンロードするだけなので高速で、Go のセットアップは不要です。
 対応: Linux / macOS / Windows、`amd64` / `arm64`。
 
+認証情報を `with:` に渡すと setup ステップで環境変数へ設定され、以降のステップは `env:` 指定なしで
+`backlog` を実行できます（設定を 1 か所に集約）。
+
 ```yaml
-- uses: yacchi/backlog-cli@v0.27.0
+- uses: yacchi/backlog-cli@v0
   with:
-    version: 0.27.0        # 省略時は最新リリース ("latest")
-- run: backlog issue list --json
-  env:
-    BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
-    BACKLOG_SPACE: your-space
-    BACKLOG_DOMAIN: backlog.jp        # backlog.jp または backlog.com
-    BACKLOG_ACCESS_MODE: read-only    # 任意: 書き込み系コマンドを無効化
+    api-key: ${{ secrets.BACKLOG_API_KEY }}
+    space: your-space
+    domain: backlog.jp            # backlog.jp または backlog.com
+    access-mode: read-only        # 任意: 書き込み系コマンドを無効化
+- run: backlog issue list --json   # env 指定不要
+- run: backlog issue view ABC-1
 ```
+
+`api-key` はログでマスクされます。複数ジョブで共有したい場合は、代わりにジョブ／ワークフローレベルの
+`env:`（`BACKLOG_API_KEY` / `BACKLOG_SPACE` / `BACKLOG_DOMAIN` / `BACKLOG_ACCESS_MODE`）に設定しても
+同じ効果が得られます。
 
 **inputs**
 
-| 名前              | デフォルト             | 説明                                                       |
-|-----------------|-------------------|----------------------------------------------------------|
-| `version`       | `latest`          | インストールするバージョン。`0.27.0` / `v0.27.0` / `latest` を受け付ける。 |
-| `github-token`  | `${{ github.token }}` | リリース情報の取得・アセットのダウンロードに使うトークン。                           |
-| `verify-checksum` | `true`            | `checksums.txt` によるダウンロードアーカイブの検証を行うか。                   |
+| 名前              | デフォルト             | 説明                                                                 |
+|-----------------|-------------------|--------------------------------------------------------------------|
+| `version`       | `latest`          | インストールするバージョン。`0.28.0` / `v0.28.0` / `latest` を受け付ける。           |
+| `github-token`  | `${{ github.token }}` | リリース情報の取得・アセットのダウンロードに使うトークン。                                     |
+| `verify-checksum` | `true`            | `checksums.txt` によるダウンロードアーカイブの検証を行うか。                             |
+| `api-key`       | （空）              | Backlog API キー。設定すると `BACKLOG_API_KEY` として後続ステップへ export（マスク付き）。 |
+| `space`         | （空）              | Backlog スペース名。設定すると `BACKLOG_SPACE` として後続ステップへ export。            |
+| `domain`        | （空）              | Backlog ドメイン。設定すると `BACKLOG_DOMAIN` として後続ステップへ export。            |
+| `access-mode`   | （空）              | `read-only` で書き込み系を無効化。設定すると `BACKLOG_ACCESS_MODE` として export。   |
 
 **outputs**: `version`（インストールしたバージョン）、`path`（`backlog` 実行ファイルの絶対パス）。
 
-**バージョン参照**: 特定バージョンに固定したい場合は `@v0.27.0`、最新のメジャー系列を追従したい場合は
-浮動タグ `@v0` を使えます（`@v0` は安定版リリースのたびに最新へ更新されます）。
+#### アクションのバージョン参照（`uses:` の `@` 指定）
+
+CI での参照方法は 3 通りあります。用途に応じて選んでください。
+
+| 方式             | 例                        | 特徴 / 向く用途                                                       |
+|----------------|--------------------------|----------------------------------------------------------------|
+| 浮動メジャータグ       | `@v0`                    | v0 系列の最新に自動追従（安定版リリースごとに更新）。手軽さ重視。**可変**。                  |
+| バージョンタグ        | `@v0.28.0`               | 特定リリースに固定。タグは移動しないため再現性が高い。**推奨のデフォルト**。                 |
+| コミット SHA        | `@<40桁のコミットSHA>`         | タグ改ざんの影響を受けない最も厳格な固定。サプライチェーン安全性重視（OpenSSF/Dependabot 推奨）。 |
 
 ```yaml
-- uses: yacchi/backlog-cli@v0        # v0 系列の最新に追従
+# 浮動メジャータグ（最新に追従・手軽）
+- uses: yacchi/backlog-cli@v0
+
+# バージョンタグ（再現性重視）
+- uses: yacchi/backlog-cli@v0.28.0
+
+# コミット SHA（最も厳格。コメントでバージョンを併記すると管理しやすい）
+- uses: yacchi/backlog-cli@0000000000000000000000000000000000000000  # v0.28.0
+```
+
+> `@v0` はリリースのたびに force-push で貼り替わる**可変タグ**です。厳密な再現性やサプライチェーン
+> 安全性が必要な場合はバージョンタグか SHA を使ってください。特定バージョンの SHA は
+> `git rev-parse v0.28.0^{commit}` で取得できます。Dependabot（`package-ecosystem: github-actions`）を
+> 使うと SHA ピン留めの更新も自動化できます。
+
+**注意（2 つのバージョンは別物）**: `uses: ...@REF` は「アクション（`action.yml`）のバージョン」、
+`with.version` は「インストールする CLI バイナリのバージョン」を指します。完全な再現性が必要な場合は
+両方を固定してください。
+
+```yaml
+- uses: yacchi/backlog-cli@v0.28.0
+  with:
+    version: 0.28.0
 ```
 
 ### Claude Code プラグイン

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,22 @@ inputs:
     description: 'Verify the downloaded archive against checksums.txt from the release.'
     required: false
     default: 'true'
+  api-key:
+    description: 'Backlog API key. When set, it is exported to the environment (BACKLOG_API_KEY) for subsequent steps.'
+    required: false
+    default: ''
+  space:
+    description: 'Backlog space name. When set, it is exported to the environment (BACKLOG_SPACE) for subsequent steps.'
+    required: false
+    default: ''
+  domain:
+    description: 'Backlog domain (backlog.jp or backlog.com). When set, it is exported to the environment (BACKLOG_DOMAIN) for subsequent steps.'
+    required: false
+    default: ''
+  access-mode:
+    description: 'Set to "read-only" to disable write commands. When set, it is exported to the environment (BACKLOG_ACCESS_MODE) for subsequent steps.'
+    required: false
+    default: ''
 
 outputs:
   version:
@@ -131,3 +147,29 @@ runs:
         echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
         echo "path=${INSTALL_DIR}/${BIN}" >> "${GITHUB_OUTPUT}"
         echo "Installed backlog CLI ${VERSION} to ${INSTALL_DIR}/${BIN}"
+
+    # 認証情報が渡された場合は環境変数へ export し、以降のステップで
+    # env: 指定なしに backlog コマンドを実行できるようにする。
+    - id: configure
+      shell: bash
+      env:
+        INPUT_API_KEY: ${{ inputs.api-key }}
+        INPUT_SPACE: ${{ inputs.space }}
+        INPUT_DOMAIN: ${{ inputs.domain }}
+        INPUT_ACCESS_MODE: ${{ inputs.access-mode }}
+      run: |
+        set -euo pipefail
+        if [ -n "${INPUT_API_KEY}" ]; then
+          echo "::add-mask::${INPUT_API_KEY}"
+          echo "BACKLOG_API_KEY=${INPUT_API_KEY}" >> "${GITHUB_ENV}"
+          echo "Exported BACKLOG_API_KEY for subsequent steps."
+        fi
+        if [ -n "${INPUT_SPACE}" ]; then
+          echo "BACKLOG_SPACE=${INPUT_SPACE}" >> "${GITHUB_ENV}"
+        fi
+        if [ -n "${INPUT_DOMAIN}" ]; then
+          echo "BACKLOG_DOMAIN=${INPUT_DOMAIN}" >> "${GITHUB_ENV}"
+        fi
+        if [ -n "${INPUT_ACCESS_MODE}" ]; then
+          echo "BACKLOG_ACCESS_MODE=${INPUT_ACCESS_MODE}" >> "${GITHUB_ENV}"
+        fi


### PR DESCRIPTION
## 概要

CI で「認証情報を一度だけ設定し、以後は指定なしで `backlog` を使う」ワークフローを容易にするため、setup アクションに認証情報の入力を追加します。値は `$GITHUB_ENV` へ export され、後続ステップは `env:` 指定なしでコマンドを実行できます。

```yaml
- uses: yacchi/backlog-cli@v0
  with:
    api-key: ${{ secrets.BACKLOG_API_KEY }}
    space: your-space
    domain: backlog.jp
    access-mode: read-only        # 任意
- run: backlog issue list --json   # env 指定不要
- run: backlog issue view ABC-1
```

## 変更内容

- **`action.yml`**: 入力 `api-key` / `space` / `domain` / `access-mode` を追加。渡された値のみ `BACKLOG_API_KEY` / `BACKLOG_SPACE` / `BACKLOG_DOMAIN` / `BACKLOG_ACCESS_MODE` として `$GITHUB_ENV` に export。`api-key` は `::add-mask::` でログマスク。CLI 本体の変更は不要（既存の環境変数読み取りを利用）。
- **`README.md`**: `with:` への集約例、ジョブ／ワークフロー級 `env:` の代替、inputs 表に新入力を追記。
- **`test-setup-action.yml`**: `space`/`domain` 入力を渡し、後続ステップで `$BACKLOG_SPACE`/`$BACKLOG_DOMAIN` が export されることを検証するステップを追加。

## 設計メモ

- CI では認証情報は「その run 限りの環境変数」で渡すのが適切なため、keyring/config への永続ログインは対象外。
- 複数ジョブで共有したい場合はジョブ／ワークフロー級 `env:` を使う（README に明記）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)